### PR TITLE
Update GitHub links to not use hardcoded urls

### DIFF
--- a/scripts/008-psl1ght.sh
+++ b/scripts/008-psl1ght.sh
@@ -2,7 +2,7 @@
 # psl1ght.sh by Naomi Peori (naomi@peori.ca)
 
 ## Download the source code.
-wget --no-check-certificate https://github.com/PS3SDK-Misc/PSL1GHT-buk/archive/92140633f376b59398d4a37ce436f4677b357218.tar.gz -O psl1ght.tar.gz
+wget --no-check-certificate https://github.com/PS3SDK-Misc/PSL1GHT-buk/tarball/main -O psl1ght.tar.gz
 
 ## Unpack the source code.
 rm -Rf psl1ght && mkdir psl1ght && tar --strip-components=1 --directory=psl1ght -xvzf psl1ght.tar.gz

--- a/scripts/009-libraries.sh
+++ b/scripts/009-libraries.sh
@@ -2,7 +2,7 @@
 # ps3libraries.sh by Naomi Peori (naomi@peori.ca)
 
 ## Download the source code.
-wget --no-check-certificate https://github.com/PS3SDK-Misc/libraries-buk/archive/9f8ae20231aafcdd5b3b8f774be21ffa08ccb0b5.tar.gz -O libraries.tar.gz
+wget --no-check-certificate https://github.com/PS3SDK-Misc/libraries-buk/tarball/main -O libraries.tar.gz
 
 ## Unpack the source code.
 rm -Rf libraries && mkdir libraries && tar --strip-components=1 --directory=libraries -xvzf libraries.tar.gz && cd libraries

--- a/scripts/010-extralibs.sh
+++ b/scripts/010-extralibs.sh
@@ -2,7 +2,7 @@
 # ps3libraries.sh by Naomi Peori (naomi@peori.ca)
 
 ## Download the source code.
-wget --no-check-certificate https://github.com/PS3SDK-Misc/extralibs/archive/a268ac81834fa6cb1310e3026a58d28f61376cf7.tar.gz -O extralibs.tar.gz
+wget --no-check-certificate https://github.com/PS3SDK-Misc/extralibs/tarball/main -O extralibs.tar.gz
 
 ## Unpack the source code.
 rm -Rf extralibs && mkdir extralibs && tar --strip-components=1 --directory=extralibs -xvzf extralibs.tar.gz && cd extralibs


### PR DESCRIPTION
Makes it easier than having to update the hardcoded hash every time one of the dependency repos has an update.